### PR TITLE
Upgrade opensource COBOL 4J v1.0.14 to v1.0.15

### DIFF
--- a/.github/workflows/docker-compose-for-compiler-developers.yml
+++ b/.github/workflows/docker-compose-for-compiler-developers.yml
@@ -13,5 +13,5 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-          #- name: Launch docker containers
-          #  run: cd docker-compose-for-compiler-developers && docker compose up -d
+      - name: Launch docker containers
+        run: cd docker-compose-for-compiler-developers && docker compose up -d

--- a/.github/workflows/docker-compose-for-compiler-developers.yml
+++ b/.github/workflows/docker-compose-for-compiler-developers.yml
@@ -13,5 +13,5 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Launch docker containers
-        run: cd docker-compose-for-compiler-developers && docker compose up -d
+          #- name: Launch docker containers
+          #  run: cd docker-compose-for-compiler-developers && docker compose up -d

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -13,5 +13,5 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Launch docker containers
-        run: cd docker-compose && docker compose up -d
+          #- name: Launch docker containers
+          #  run: cd docker-compose && docker compose up -d

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -13,5 +13,5 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-          #- name: Launch docker containers
-          #  run: cd docker-compose && docker compose up -d
+      - name: Launch docker containers
+        run: cd docker-compose && docker compose up -d

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,14 +17,14 @@ RUN apt-get update && apt-get install -y sbt
 
 # install opensourcecobol4j
 RUN cd /root &&\
-    curl -L -o opensourcecobol4j-v1.0.14.tar.gz https://github.com/opensourcecobol/opensourcecobol4j/archive/refs/tags/v1.0.14.tar.gz &&\
-    tar zxvf opensourcecobol4j-v1.0.14.tar.gz &&\
-    cd opensourcecobol4j-1.0.14 &&\
+    curl -L -o opensourcecobol4j-v1.0.15.tar.gz https://github.com/opensourcecobol/opensourcecobol4j/archive/refs/tags/v1.0.15.tar.gz &&\
+    tar zxvf opensourcecobol4j-v1.0.15.tar.gz &&\
+    cd opensourcecobol4j-1.0.15 &&\
     curl -L -o libcobj/sqlite-jdbc/sqlite.jar https://github.com/xerial/sqlite-jdbc/releases/download/3.36.0.3/sqlite-jdbc-3.36.0.3.jar &&\
     ./configure --prefix=/usr/ &&\
     make &&\
     make install &&\
-    rm ../opensourcecobol4j-v1.0.14.tar.gz
+    rm ../opensourcecobol4j-v1.0.15.tar.gz
 
 # Install Open COBOL ESQL 4J
 RUN mkdir -p /usr/lib/Open-COBOL-ESQL-4j &&\

--- a/docker-compose-for-compiler-developers/Dockerfile
+++ b/docker-compose-for-compiler-developers/Dockerfile
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 
 # install dependencies of opensourcecobol 4J and Open COBOL ESQL 4J
 RUN apt-get update &&\
-    apt-get install -y default-jdk build-essential bison flex gettext texinfo libgmp-dev autoconf git unzip zip &&\
+    apt-get install -y default-jdk build-essential bison flex gettext texinfo libgmp-dev autoconf libtool git unzip zip &&\
     curl -s "https://get.sdkman.io" | bash &&\
     source "/root/.sdkman/bin/sdkman-init.sh" &&\
     sdk install sbt

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "5432:5432"
 
   oc4j_client:
-    image: opensourcecobol/opensourcecobol4j:1.0.14
+    image: opensourcecobol/opensourcecobol4j:1.0.15
     container_name: oc4j_client
     stdin_open: true
     tty: true


### PR DESCRIPTION
Upgrade opensource COBOL 4J v1.0.14 to v1.0.15.
Temporarily some CI processes are disabled.
I will enable them after I  upload a new docker image to Docker Hub.