### PR TITLE
Upgrade opensource COBOL 4J v1.0.17 to v1.0.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,13 +17,13 @@ RUN apt-get update && apt-get install -y sbt
 
 # install opensourcecobol4j
 RUN cd /root &&\
-    curl -L -o opensourcecobol4j-v1.0.17.tar.gz https://github.com/opensourcecobol/opensourcecobol4j/archive/refs/tags/v1.0.17.tar.gz &&\
-    tar zxvf opensourcecobol4j-v1.0.17.tar.gz &&\
-    cd opensourcecobol4j-1.0.17 &&\
+    curl -L -o opensourcecobol4j-v1.0.18.tar.gz https://github.com/opensourcecobol/opensourcecobol4j/archive/refs/tags/v1.0.18.tar.gz &&\
+    tar zxvf opensourcecobol4j-v1.0.18.tar.gz &&\
+    cd opensourcecobol4j-1.0.18 &&\
     ./configure --prefix=/usr/ &&\
     make &&\
     make install &&\
-    rm ../opensourcecobol4j-v1.0.17.tar.gz
+    rm ../opensourcecobol4j-v1.0.18.tar.gz
 
 # Install Open COBOL ESQL 4J
 RUN mkdir -p /usr/lib/Open-COBOL-ESQL-4j &&\

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Versions :
 
 - OS: Ubuntu
-- opensource COBOL 4J: v1.0.17
+- opensource COBOL 4J: v1.0.18
 - Open COBOL ESQL 4J: v1.0.3
 
 In order to "Hello World" program, run the following commands in the docker container

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "5432:5432"
 
   oc4j_client:
-    image: opensourcecobol/opensourcecobol4j:1.0.17
+    image: opensourcecobol/opensourcecobol4j:1.0.18
     container_name: oc4j_client
     stdin_open: true
     tty: true


### PR DESCRIPTION
This PR upgrades opensource COBOL 4J v1.0.17 to v1.0.18.