### PR TITLE
Upgrade opensource COBOL 4J v1.0.18 to v1.0.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,13 +17,13 @@ RUN apt-get update && apt-get install -y sbt
 
 # install opensourcecobol4j
 RUN cd /root &&\
-    curl -L -o opensourcecobol4j-v1.0.18.tar.gz https://github.com/opensourcecobol/opensourcecobol4j/archive/refs/tags/v1.0.18.tar.gz &&\
-    tar zxvf opensourcecobol4j-v1.0.18.tar.gz &&\
-    cd opensourcecobol4j-1.0.18 &&\
+    curl -L -o opensourcecobol4j-v1.0.19.tar.gz https://github.com/opensourcecobol/opensourcecobol4j/archive/refs/tags/v1.0.19.tar.gz &&\
+    tar zxvf opensourcecobol4j-v1.0.19.tar.gz &&\
+    cd opensourcecobol4j-1.0.19 &&\
     ./configure --prefix=/usr/ &&\
     make &&\
     make install &&\
-    rm ../opensourcecobol4j-v1.0.18.tar.gz
+    rm ../opensourcecobol4j-v1.0.19.tar.gz
 
 # Install Open COBOL ESQL 4J
 RUN mkdir -p /usr/lib/Open-COBOL-ESQL-4j &&\


### PR DESCRIPTION
This PR upgrades opensource COBOL 4J v1.0.18 to v1.0.19.