### PR TITLE
opensource COBOL 4J 1.1.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,13 @@ RUN curl -fL https://github.com/coursier/coursier/releases/latest/download/cs-x8
 
 # install opensourcecobol4j
 RUN cd /root &&\
-    curl -L -o opensourcecobol4j-v1.1.2.tar.gz https://github.com/opensourcecobol/opensourcecobol4j/archive/refs/tags/v1.1.2.tar.gz &&\
-    tar zxvf opensourcecobol4j-v1.1.2.tar.gz &&\
-    cd opensourcecobol4j-1.1.2 &&\
+    curl -L -o opensourcecobol4j-v1.1.3.tar.gz https://github.com/opensourcecobol/opensourcecobol4j/archive/refs/tags/v1.1.3.tar.gz &&\
+    tar zxvf opensourcecobol4j-v1.1.3.tar.gz &&\
+    cd opensourcecobol4j-1.1.3 &&\
     ./configure --prefix=/usr/ &&\
     make &&\
     make install &&\
-    rm ../opensourcecobol4j-v1.1.2.tar.gz
+    rm ../opensourcecobol4j-v1.1.3.tar.gz
 
 # Install Open COBOL ESQL 4J
 ENV PATH="$PATH:/root/.local/share/coursier/bin"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Versions :
 
 - OS: Ubuntu
-- opensource COBOL 4J: v1.1.2
+- opensource COBOL 4J: v1.1.3
 - Open COBOL ESQL 4J: v1.1.1
 
 In order to "Hello World" program, run the following commands in the docker container

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "5432:5432"
 
   oc4j_client:
-    image: opensourcecobol/opensourcecobol4j:1.1.3
+    image: opensourcecobol/opensourcecobol4j:20241031
     container_name: oc4j_client
     stdin_open: true
     tty: true

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "5432:5432"
 
   oc4j_client:
-    image: opensourcecobol/opensourcecobol4j:1.1.2
+    image: opensourcecobol/opensourcecobol4j:1.1.3
     container_name: oc4j_client
     stdin_open: true
     tty: true


### PR DESCRIPTION
This pull request updates the version of OpenSource COBOL 4J used in the project from v1.1.2 to v1.1.3. The changes include updates to the Dockerfile, the README file, and the Docker Compose configuration.

Version updates:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L18-R24): Updated the download link and installation commands to use OpenSource COBOL 4J version 1.1.3 instead of 1.1.2.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R7): Updated the version information for OpenSource COBOL 4J from v1.1.2 to v1.1.3.
* [`docker-compose/docker-compose.yml`](diffhunk://#diff-21796814c2204c04ba29b3834e57d5399c2ba04589de42b2be845cf6a0309b11L15-R15): Updated the Docker image for OpenSource COBOL 4J to version 1.1.3.